### PR TITLE
Force the change to avoid leaving negative numbers behind

### DIFF
--- a/web/actions/team_actions.ex
+++ b/web/actions/team_actions.ex
@@ -154,7 +154,9 @@ defmodule Api.TeamActions do
           Multi.update(
             multi,
             "#{team.id} to shuffled",
-            Changeset.change(team, tie_breaker: new_tb)
+            team
+            |> Changeset.change()
+            |> Changeset.force_change(:tie_breaker, new_tb)
           )
         end
       )


### PR DESCRIPTION
Used something like the following patch to verify.
```
diff --git a/web/actions/team_actions.ex b/web/actions/team_actions.ex
index 92e3b7a..34b6fda 100644
--- a/web/actions/team_actions.ex
+++ b/web/actions/team_actions.ex
@@ -161,7 +161,12 @@ defmodule Api.TeamActions do
         end
       )
 
-    Repo.transaction(multi)
+    res = Repo.transaction(multi)
+    [] =
+      Repo.all(Team)
+      |> Enum.map(&(&1.tie_breaker))
+      |> Enum.filter(&(&1 < 0))
+    res
   end
 
   def create_repo(id) do
```